### PR TITLE
Add Leaflet maps, markers and sample seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Fuel-Queue-Management-System/
 1. Start **MySQL** (e.g., via XAMPP Control Panel).
 2. Open **phpMyAdmin** or your preferred MySQL client.
 3. Import **`database/fqms.sql`** to create the `fqms` database, necessary tables, and initial demo data.
+4. (Optional) Import **`database/sample_stations_seed.sql`** to add multiple demo stations with coordinates for the map.
 
 ### Configuration
 Database settings are located in `backend/config.php` and default to:
@@ -584,27 +585,37 @@ The system now includes interactive maps powered by **Leaflet.js** with **OpenSt
 ### Map Features
 
 - **User Dashboard Map** (`frontend/dashboard.html`):
-  - Displays all fuel stations with dynamic markers (when coordinates are available in the database).
-  - Default center: Sri Lanka (6.9271, 79.8612) | Zoom: 13
-  - Click markers to see station name and location
+  - Displays **all fuel stations dynamically from the database** (via `backend/stations.php`) as markers (only when coordinates are available).
+  - Default center: **Sri Lanka** (6.9271, 79.8612) | Default zoom: **7** (auto-fits bounds when multiple stations have coordinates).
+  - Click markers to see:
+    - Station name + location
+    - Fuel availability (Petrol/Diesel/Both/None)
+    - Queue length (vehicles)
+    - Available (Yes/No)
   - Map container: 400px height, responsive design
 
 - **Owner Dashboard Map** (`frontend/owner-dashboard.html`):
-  - Shows the owner's station location with a marker
-  - Default center: Sri Lanka (6.9271, 79.8612) if coordinates not set
-  - Updates marker position when coordinates are available
-  - Shows popup: "Fuel Station Location"
+  - Displays **multiple stations dynamically** (same data source as the user dashboard) for quick comparison.
+  - Also pins **your station** (when coordinates are set) with a "Your Station" popup.
+  - Default center: Sri Lanka (6.9271, 79.8612) if coordinates are not set (auto-fits bounds when other stations have coordinates).
   - Map container: 400px height, responsive design
+
+### Marker Colors
+
+Markers are color-coded based on station status returned by the backend:
+- **Green**: `available`
+- **Yellow**: `limited`
+- **Red**: `nofuel`
 
 ### Technical Implementation
 
 **Frontend Files Updated**:
 - `frontend/dashboard.html` — Leaflet CSS/JS CDN includes (v1.9.4), map container `<div id="mapUser">`
 - `frontend/owner-dashboard.html` — Leaflet CSS/JS CDN includes (v1.9.4), map container `<div id="mapOwner">`
-- `frontend/css/dashboard.css` — `.map-container` styling (400px height, rounded corners, dashed border)
+- `frontend/css/dashboard.css` — `.map-container` styling + status-colored marker + popup styling
 - `frontend/css/owner-dashboard.css` — `.map-container` styling
-- `frontend/js/dashboard.js` — `initUserMap()` function, `addMarkersFromState()` function, marker handling
-- `frontend/js/owner-dashboard.js` — `initOwnerMap()` function, marker management
+- `frontend/js/dashboard.js` — initializes Leaflet, fetches stations, validates coordinates, renders **multiple markers** + popups
+- `frontend/js/owner-dashboard.js` — initializes Leaflet, loads owner station + also renders **multiple markers** + popups
 
 **Backend Files Updated**:
 - `backend/stations.php` — Returns `latitude` and `longitude` fields (float|null) for each station
@@ -639,6 +650,24 @@ The system now includes interactive maps powered by **Leaflet.js** with **OpenSt
 UPDATE fuel_stations 
 SET latitude = 6.9271, longitude = 79.8612 
 WHERE station_id = 1;
+```
+
+### Adding Coordinates for New Stations
+
+When a new station is created (owner registration flow), you can set coordinates later in MySQL:
+
+```sql
+UPDATE fuel_stations
+SET latitude = 7.2906, longitude = 80.6337
+WHERE station_id = 2;
+```
+
+### Importing Sample Stations (Quick Demo)
+
+To quickly populate multiple stations (with queue + availability + coordinates) for Leaflet markers:
+
+```bash
+mysql -u root -p fqms < database/sample_stations_seed.sql
 ```
 
 **Method 2: Edit Default Center in Code**

--- a/database/sample_stations_seed.sql
+++ b/database/sample_stations_seed.sql
@@ -1,0 +1,195 @@
+-- Sample Fuel Stations Seed (FQMS)
+-- Safe to import multiple times (uses INSERT IGNORE / ON DUPLICATE KEY UPDATE where possible)
+-- Requires: database/fqms.sql already imported (tables exist)
+
+USE `fqms`;
+
+START TRANSACTION;
+
+-- ---------------------------------------------------------------------------
+-- 1) Fuel stations with coordinates (Sri Lanka)
+-- ---------------------------------------------------------------------------
+-- Note: station_id is auto-increment; we identify rows by station_name for id lookup.
+INSERT IGNORE INTO fuel_stations (station_name, location, latitude, longitude)
+VALUES
+  ('Ceypetco — Colombo', 'Colombo', 6.92710000, 79.86120000),
+  ('IOC — Kandy', 'Kandy', 7.29060000, 80.63370000),
+  ('Ceypetco — Galle', 'Galle', 6.05350000, 80.22100000),
+  ('IOC — Jaffna', 'Jaffna', 9.66150000, 80.02550000),
+  ('Ceypetco — Kurunegala', 'Kurunegala', 7.48630000, 80.36220000),
+  ('IOC — Anuradhapura', 'Anuradhapura', 8.31140000, 80.40370000),
+  ('Ceypetco — Trincomalee', 'Trincomalee', 8.58740000, 81.21520000),
+  ('IOC — Matara', 'Matara', 5.95490000, 80.55490000);
+
+-- ---------------------------------------------------------------------------
+-- 2) Ensure queue_status exists for each station (1 row per station)
+-- ---------------------------------------------------------------------------
+INSERT IGNORE INTO queue_status (station_id, queue_length, waiting_time, service_rate, active_pumps)
+SELECT fs.station_id, 0, 0, 5.00, 2
+FROM fuel_stations fs
+WHERE fs.station_name IN (
+  'Ceypetco — Colombo',
+  'IOC — Kandy',
+  'Ceypetco — Galle',
+  'IOC — Jaffna',
+  'Ceypetco — Kurunegala',
+  'IOC — Anuradhapura',
+  'Ceypetco — Trincomalee',
+  'IOC — Matara'
+)
+ON DUPLICATE KEY UPDATE
+  queue_length = VALUES(queue_length),
+  waiting_time = VALUES(waiting_time),
+  service_rate = VALUES(service_rate),
+  active_pumps = VALUES(active_pumps),
+  updated_at = CURRENT_TIMESTAMP;
+
+-- ---------------------------------------------------------------------------
+-- 3) Ensure fuel availability rows exist (1 row per (station, fuel_type))
+-- fuel_type_id: 1 = Petrol, 2 = Diesel
+-- ---------------------------------------------------------------------------
+INSERT IGNORE INTO fuel_availability (station_id, fuel_type_id, is_available)
+SELECT fs.station_id, 1, 1
+FROM fuel_stations fs
+WHERE fs.station_name IN (
+  'Ceypetco — Colombo',
+  'IOC — Kandy',
+  'Ceypetco — Galle',
+  'IOC — Jaffna',
+  'Ceypetco — Kurunegala',
+  'IOC — Anuradhapura',
+  'Ceypetco — Trincomalee',
+  'IOC — Matara'
+);
+
+INSERT IGNORE INTO fuel_availability (station_id, fuel_type_id, is_available)
+SELECT fs.station_id, 2, 1
+FROM fuel_stations fs
+WHERE fs.station_name IN (
+  'Ceypetco — Colombo',
+  'IOC — Kandy',
+  'Ceypetco — Galle',
+  'IOC — Jaffna',
+  'Ceypetco — Kurunegala',
+  'IOC — Anuradhapura',
+  'Ceypetco — Trincomalee',
+  'IOC — Matara'
+);
+
+-- ---------------------------------------------------------------------------
+-- 4) Set some realistic demo values (queue + availability)
+-- ---------------------------------------------------------------------------
+-- Colombo: Petrol yes, Diesel no, queue 24
+UPDATE queue_status qs
+JOIN fuel_stations fs ON fs.station_id = qs.station_id
+SET qs.queue_length = 24,
+    qs.waiting_time = 48,
+    qs.updated_at = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'Ceypetco — Colombo';
+
+UPDATE fuel_availability fa
+JOIN fuel_stations fs ON fs.station_id = fa.station_id
+SET fa.is_available = CASE WHEN fa.fuel_type_id = 1 THEN 1 ELSE 0 END,
+    fa.last_updated = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'Ceypetco — Colombo';
+
+-- Kandy: both yes, queue 8
+UPDATE queue_status qs
+JOIN fuel_stations fs ON fs.station_id = qs.station_id
+SET qs.queue_length = 8,
+    qs.waiting_time = 16,
+    qs.updated_at = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'IOC — Kandy';
+
+UPDATE fuel_availability fa
+JOIN fuel_stations fs ON fs.station_id = fa.station_id
+SET fa.is_available = 1,
+    fa.last_updated = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'IOC — Kandy';
+
+-- Galle: Petrol no, Diesel yes, queue 14
+UPDATE queue_status qs
+JOIN fuel_stations fs ON fs.station_id = qs.station_id
+SET qs.queue_length = 14,
+    qs.waiting_time = 28,
+    qs.updated_at = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'Ceypetco — Galle';
+
+UPDATE fuel_availability fa
+JOIN fuel_stations fs ON fs.station_id = fa.station_id
+SET fa.is_available = CASE WHEN fa.fuel_type_id = 1 THEN 0 ELSE 1 END,
+    fa.last_updated = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'Ceypetco — Galle';
+
+-- Jaffna: none, queue 3
+UPDATE queue_status qs
+JOIN fuel_stations fs ON fs.station_id = qs.station_id
+SET qs.queue_length = 3,
+    qs.waiting_time = 6,
+    qs.updated_at = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'IOC — Jaffna';
+
+UPDATE fuel_availability fa
+JOIN fuel_stations fs ON fs.station_id = fa.station_id
+SET fa.is_available = 0,
+    fa.last_updated = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'IOC — Jaffna';
+
+-- Kurunegala: both yes, queue 18
+UPDATE queue_status qs
+JOIN fuel_stations fs ON fs.station_id = qs.station_id
+SET qs.queue_length = 18,
+    qs.waiting_time = 36,
+    qs.updated_at = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'Ceypetco — Kurunegala';
+
+UPDATE fuel_availability fa
+JOIN fuel_stations fs ON fs.station_id = fa.station_id
+SET fa.is_available = 1,
+    fa.last_updated = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'Ceypetco — Kurunegala';
+
+-- Anuradhapura: Petrol yes, Diesel yes, queue 0
+UPDATE queue_status qs
+JOIN fuel_stations fs ON fs.station_id = qs.station_id
+SET qs.queue_length = 0,
+    qs.waiting_time = 0,
+    qs.updated_at = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'IOC — Anuradhapura';
+
+UPDATE fuel_availability fa
+JOIN fuel_stations fs ON fs.station_id = fa.station_id
+SET fa.is_available = 1,
+    fa.last_updated = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'IOC — Anuradhapura';
+
+-- Trincomalee: limited (Diesel only), queue 11
+UPDATE queue_status qs
+JOIN fuel_stations fs ON fs.station_id = qs.station_id
+SET qs.queue_length = 11,
+    qs.waiting_time = 22,
+    qs.updated_at = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'Ceypetco — Trincomalee';
+
+UPDATE fuel_availability fa
+JOIN fuel_stations fs ON fs.station_id = fa.station_id
+SET fa.is_available = CASE WHEN fa.fuel_type_id = 1 THEN 0 ELSE 1 END,
+    fa.last_updated = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'Ceypetco — Trincomalee';
+
+-- Matara: both yes, queue 9
+UPDATE queue_status qs
+JOIN fuel_stations fs ON fs.station_id = qs.station_id
+SET qs.queue_length = 9,
+    qs.waiting_time = 18,
+    qs.updated_at = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'IOC — Matara';
+
+UPDATE fuel_availability fa
+JOIN fuel_stations fs ON fs.station_id = fa.station_id
+SET fa.is_available = 1,
+    fa.last_updated = CURRENT_TIMESTAMP
+WHERE fs.station_name = 'IOC — Matara';
+
+COMMIT;
+

--- a/frontend/css/dashboard.css
+++ b/frontend/css/dashboard.css
@@ -227,6 +227,48 @@ body {
 .dot.yellow { background: var(--status-limited); }
 .dot.red { background: var(--status-nofuel); }
 
+/* Leaflet markers (status-colored) */
+.fqms-marker {
+  background: transparent !important;
+  border: none !important;
+}
+
+.fqms-marker__dot {
+  display: block;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 2px solid #fff;
+  box-shadow: 0 8px 18px rgba(17, 24, 39, 0.22);
+}
+
+.fqms-marker--available .fqms-marker__dot { background: var(--status-available); }
+.fqms-marker--limited .fqms-marker__dot { background: var(--status-limited); }
+.fqms-marker--nofuel .fqms-marker__dot { background: var(--status-nofuel); }
+
+/* Leaflet popup tweaks */
+.fqms-popup__title {
+  font-weight: 900;
+  font-size: 1.05rem;
+  margin-bottom: 4px;
+}
+
+.fqms-popup__meta {
+  color: var(--muted);
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.fqms-popup__meta i {
+  color: var(--primary);
+  margin-right: 6px;
+}
+
+.fqms-popup__row {
+  margin-top: 4px;
+  font-weight: 700;
+}
+
 .stations-wrap { margin-top: 18px; padding: 18px; }
 
 .section-title {

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -22,22 +22,74 @@ const state = { query: "", filter: "all", stations: [], loadError: null };
 // Leaflet map references for user dashboard
 let userMap = null;
 let userMarkersLayer = null;
+let userMarkerIcons = null;
+
+function isValidLatLng(lat, lng) {
+  const a = Number(lat);
+  const b = Number(lng);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+  if (a < -90 || a > 90) return false;
+  if (b < -180 || b > 180) return false;
+  return true;
+}
+
+function getFuelText(s) {
+  const p = Boolean(s.petrol);
+  const d = Boolean(s.diesel);
+  if (p && d) return "Petrol & Diesel";
+  if (p) return "Petrol";
+  if (d) return "Diesel";
+  return "None";
+}
+
+function getAvailabilityText(s) {
+  const any = Boolean(s.petrol) || Boolean(s.diesel);
+  return any ? "Yes" : "No";
+}
+
+function getMarkerIcons() {
+  if (userMarkerIcons) return userMarkerIcons;
+  if (typeof L === "undefined") return null;
+
+  function icon(className) {
+    return L.divIcon({
+      className: `fqms-marker ${className}`,
+      html: '<span class="fqms-marker__dot" aria-hidden="true"></span>',
+      iconSize: [18, 18],
+      iconAnchor: [9, 9],
+      popupAnchor: [0, -10],
+    });
+  }
+
+  userMarkerIcons = {
+    available: icon("fqms-marker--available"),
+    limited: icon("fqms-marker--limited"),
+    nofuel: icon("fqms-marker--nofuel"),
+    fallback: icon("fqms-marker--limited"),
+  };
+  return userMarkerIcons;
+}
 
 function initUserMap() {
   const el = document.getElementById('mapUser');
   if (!el || typeof L === 'undefined') return;
 
+  // Sri Lanka default (Colombo) — zoomed out enough to show island context.
   const defaultCenter = [6.9271, 79.8612];
   try {
     if (!userMap) {
-      userMap = L.map(el).setView(defaultCenter, 13);
+      userMap = L.map(el).setView(defaultCenter, 7);
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
         attribution: '&copy; OpenStreetMap contributors'
       }).addTo(userMap);
       userMarkersLayer = L.layerGroup().addTo(userMap);
+      // Ensure proper sizing when layout/animations finish.
+      setTimeout(() => {
+        try { userMap?.invalidateSize(); } catch (_) {}
+      }, 50);
     } else {
-      userMap.setView(defaultCenter, 13);
+      userMap.setView(defaultCenter, 7);
     }
   } catch (err) {
     console.warn('Leaflet init failed', err);
@@ -47,24 +99,55 @@ function initUserMap() {
 function addMarkersFromState() {
   if (!userMap || !userMarkersLayer) return;
   userMarkersLayer.clearLayers();
+  const icons = getMarkerIcons();
+  const points = [];
+
   (state.stations || []).forEach((s) => {
     const lat = s.latitude ?? null;
     const lng = s.longitude ?? null;
-    if (lat !== null && lng !== null) {
-      try {
-        const marker = L.marker([Number(lat), Number(lng)]);
-        marker.bindPopup(`<strong>${escapeHtml(s.station_name)}</strong><br>${escapeHtml(s.location || '')}`);
-        marker.addTo(userMarkersLayer);
-      } catch (err) {
-        // ignore invalid coords
-      }
+    if (lat === null || lng === null) return;
+    if (!isValidLatLng(lat, lng)) return;
+
+    try {
+      const status = String(s.status || "");
+      const icon =
+        (icons && (status === "available" || status === "limited" || status === "nofuel"))
+          ? icons[status]
+          : (icons?.fallback || undefined);
+
+      const marker = L.marker([Number(lat), Number(lng)], icon ? { icon } : undefined);
+      const popupHtml = [
+        `<div class="fqms-popup">`,
+        `<div class="fqms-popup__title">${escapeHtml(s.station_name)}</div>`,
+        s.location ? `<div class="fqms-popup__meta"><i class="fa-solid fa-location-dot"></i> ${escapeHtml(s.location)}</div>` : ``,
+        `<div class="fqms-popup__row"><strong>Fuel</strong>: ${escapeHtml(getFuelText(s))}</div>`,
+        `<div class="fqms-popup__row"><strong>Queue</strong>: ${Number(s.queue_length ?? 0)} Vehicles</div>`,
+        `<div class="fqms-popup__row"><strong>Available</strong>: ${escapeHtml(getAvailabilityText(s))}</div>`,
+        `</div>`,
+      ].join("");
+
+      marker.bindPopup(popupHtml);
+      marker.addTo(userMarkersLayer);
+      points.push([Number(lat), Number(lng)]);
+    } catch (err) {
+      // ignore invalid coords / leaflet issues per-station
     }
   });
+
+  // Fit map view to markers when available; otherwise keep Sri Lanka default.
+  try {
+    if (points.length === 1) {
+      userMap.setView(points[0], 13);
+    } else if (points.length > 1) {
+      const bounds = L.latLngBounds(points);
+      userMap.fitBounds(bounds.pad(0.2), { animate: false });
+    }
+  } catch (_) {}
 }
 
 function escapeHtml(str) {
   if (!str) return '';
-  return String(str).replace(/[&<>"]+/g, function (s) {
+  return String(str).replace(/[&<>"]/g, function (s) {
     return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[s]);
   });
 }

--- a/frontend/js/owner-dashboard.js
+++ b/frontend/js/owner-dashboard.js
@@ -18,6 +18,61 @@ const ownerState = {
 // Leaflet map references
 let ownerMap = null;
 let ownerMarker = null;
+let ownerMarkersLayer = null;
+let ownerMarkerIcons = null;
+
+function isValidLatLng(lat, lng) {
+  const a = Number(lat);
+  const b = Number(lng);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+  if (a < -90 || a > 90) return false;
+  if (b < -180 || b > 180) return false;
+  return true;
+}
+
+function getFuelText(s) {
+  const p = Boolean(s.petrol);
+  const d = Boolean(s.diesel);
+  if (p && d) return "Petrol & Diesel";
+  if (p) return "Petrol";
+  if (d) return "Diesel";
+  return "None";
+}
+
+function getAvailabilityText(s) {
+  const any = Boolean(s.petrol) || Boolean(s.diesel);
+  return any ? "Yes" : "No";
+}
+
+function escapeHtml(str) {
+  if (!str) return "";
+  return String(str).replace(/[&<>"]/g, function (s) {
+    return ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[s]);
+  });
+}
+
+function getMarkerIcons() {
+  if (ownerMarkerIcons) return ownerMarkerIcons;
+  if (typeof L === "undefined") return null;
+
+  function icon(className) {
+    return L.divIcon({
+      className: `fqms-marker ${className}`,
+      html: '<span class="fqms-marker__dot" aria-hidden="true"></span>',
+      iconSize: [18, 18],
+      iconAnchor: [9, 9],
+      popupAnchor: [0, -10],
+    });
+  }
+
+  ownerMarkerIcons = {
+    available: icon("fqms-marker--available"),
+    limited: icon("fqms-marker--limited"),
+    nofuel: icon("fqms-marker--nofuel"),
+    fallback: icon("fqms-marker--limited"),
+  };
+  return ownerMarkerIcons;
+}
 
 function calculateStatus() {
   const { petrolAvailable, dieselAvailable, queueLength } = ownerState;
@@ -284,23 +339,93 @@ function initOwnerMap() {
   try {
     // create map (idempotent)
     if (!ownerMap) {
-      ownerMap = L.map(el).setView(center, 13);
+      ownerMap = L.map(el).setView(center, ownerState.latitude && ownerState.longitude ? 13 : 7);
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
         attribution: '&copy; OpenStreetMap contributors'
       }).addTo(ownerMap);
+      ownerMarkersLayer = L.layerGroup().addTo(ownerMap);
+      setTimeout(() => {
+        try { ownerMap?.invalidateSize(); } catch (_) {}
+      }, 50);
     } else {
-      ownerMap.setView(center, 13);
+      ownerMap.setView(center, ownerState.latitude && ownerState.longitude ? 13 : 7);
     }
 
-    if (ownerMarker) {
-      ownerMarker.setLatLng(center);
-    } else {
-      ownerMarker = L.marker(center).addTo(ownerMap).bindPopup('Fuel Station Location');
+    if (ownerMarker) ownerMarker.remove();
+    ownerMarker = null;
+
+    if (isValidLatLng(center[0], center[1])) {
+      ownerMarker = L.marker(center).addTo(ownerMap).bindPopup("Your Station");
     }
   } catch (err) {
     console.warn('Leaflet map init failed', err);
   }
+}
+
+async function loadAllStationsForOwnerMap() {
+  // Owner is allowed to call stations.php; it requires login.
+  try {
+    const data = await apiGet("../backend/stations.php");
+    if (!data?.ok || !Array.isArray(data.stations)) return [];
+    return data.stations;
+  } catch (_) {
+    return [];
+  }
+}
+
+function renderStationsOnOwnerMap(stations) {
+  if (!ownerMap || !ownerMarkersLayer) return;
+  ownerMarkersLayer.clearLayers();
+  const icons = getMarkerIcons();
+  const points = [];
+
+  (stations || []).forEach((s) => {
+    const lat = s.latitude ?? null;
+    const lng = s.longitude ?? null;
+    if (lat === null || lng === null) return;
+    if (!isValidLatLng(lat, lng)) return;
+
+    try {
+      const status = String(s.status || "");
+      const icon =
+        (icons && (status === "available" || status === "limited" || status === "nofuel"))
+          ? icons[status]
+          : (icons?.fallback || undefined);
+
+      const marker = L.marker([Number(lat), Number(lng)], icon ? { icon } : undefined);
+      const popupHtml = [
+        `<div class="fqms-popup">`,
+        `<div class="fqms-popup__title">${escapeHtml(s.station_name)}</div>`,
+        s.location ? `<div class="fqms-popup__meta"><i class="fa-solid fa-location-dot"></i> ${escapeHtml(s.location)}</div>` : ``,
+        `<div class="fqms-popup__row"><strong>Fuel</strong>: ${escapeHtml(getFuelText(s))}</div>`,
+        `<div class="fqms-popup__row"><strong>Queue</strong>: ${Number(s.queue_length ?? 0)} Vehicles</div>`,
+        `<div class="fqms-popup__row"><strong>Available</strong>: ${escapeHtml(getAvailabilityText(s))}</div>`,
+        `</div>`,
+      ].join("");
+      marker.bindPopup(popupHtml);
+      marker.addTo(ownerMarkersLayer);
+      points.push([Number(lat), Number(lng)]);
+    } catch (_) {
+      // ignore invalid coords
+    }
+  });
+
+  try {
+    const ownLat = ownerState.latitude;
+    const ownLng = ownerState.longitude;
+    if (isValidLatLng(ownLat, ownLng)) {
+      ownerMap.setView([Number(ownLat), Number(ownLng)], 13);
+      return;
+    }
+    if (points.length > 1) {
+      ownerMap.fitBounds(L.latLngBounds(points).pad(0.2), { animate: false });
+    } else if (points.length === 1) {
+      ownerMap.setView(points[0], 13);
+    } else {
+      ownerMap.setView([6.9271, 79.8612], 7);
+    }
+  } catch (_) {}
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -430,6 +555,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   updateLastSavedTime();
   // initialize owner map (uses ownerState latitude/longitude if available)
   initOwnerMap();
+  // show all stations (dynamic markers) on owner map too
+  try {
+    const stations = await loadAllStationsForOwnerMap();
+    renderStationsOnOwnerMap(stations);
+  } catch (_) {}
 });
 
 async function performLogout(event) {


### PR DESCRIPTION
Enable interactive station maps and demo data: add database/sample_stations_seed.sql and update README with import instructions and map/marker details. Frontend CSS (dashboard.css) adds status-colored marker and popup styles. frontend/js/dashboard.js and frontend/js/owner-dashboard.js initialize Leaflet maps, validate coordinates, create status-colored divIcons, render multiple station markers with rich popups (fuel type, queue length, availability), and auto-fit map bounds (default zoom adjusted). Owner dashboard now also loads and displays all stations while still pinning the owner's station. Small safety/escaping and helper functions added to improve robustness.